### PR TITLE
Feat/migraciones de nuevos datos en tabla info complementaria

### DIFF
--- a/controllers/info_complementaria_tercero.go
+++ b/controllers/info_complementaria_tercero.go
@@ -1,29 +1,32 @@
 package controllers
 
 import (
-	"encoding/json"
-	"errors"
-	"strconv"
-	"strings"
-	"github.com/udistrital/utils_oas/time_bogota"
-	"github.com/udistrital/terceros_crud/models"
+    "encoding/json"
+    "errors"
+    "fmt"
+    "github.com/udistrital/terceros_crud/models"
+    "github.com/udistrital/utils_oas/time_bogota"
+    "strconv"
+    "strings"
 
-	"github.com/astaxie/beego"
-	"github.com/astaxie/beego/logs"
+    "github.com/astaxie/beego"
+    "github.com/astaxie/beego/logs"
+    "github.com/mitchellh/mapstructure"
 )
 
 // InfoComplementariaTerceroController operations for InfoComplementariaTercero
 type InfoComplementariaTerceroController struct {
-	beego.Controller
+    beego.Controller
 }
 
 // URLMapping ...
 func (c *InfoComplementariaTerceroController) URLMapping() {
-	c.Mapping("Post", c.Post)
-	c.Mapping("GetOne", c.GetOne)
-	c.Mapping("GetAll", c.GetAll)
-	c.Mapping("Put", c.Put)
-	c.Mapping("Delete", c.Delete)
+    c.Mapping("Post", c.Post)
+    c.Mapping("PostPadre", c.PostPadre)
+    c.Mapping("GetOne", c.GetOne)
+    c.Mapping("GetAll", c.GetAll)
+    c.Mapping("Put", c.Put)
+    c.Mapping("Delete", c.Delete)
 }
 
 // Post ...
@@ -34,26 +37,282 @@ func (c *InfoComplementariaTerceroController) URLMapping() {
 // @Failure 400 the request contains incorrect syntax
 // @router / [post]
 func (c *InfoComplementariaTerceroController) Post() {
-	var v models.InfoComplementariaTercero
-	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
-		v.FechaCreacion = time_bogota.TiempoBogotaFormato()
-		v.FechaModificacion = time_bogota.TiempoBogotaFormato()
-		if _, err := models.AddInfoComplementariaTercero(&v); err == nil {
-			c.Ctx.Output.SetStatus(201)
-			c.Data["json"] = v
-		} else {
-			logs.Error(err)
-			//c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
-			c.Data["system"] = err
-			c.Abort("400")
-		}
-	} else {
-		logs.Error(err)
-		//c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
-		c.Data["system"] = err
-		c.Abort("400")
-	}
-	c.ServeJSON()
+    var v models.InfoComplementariaTercero
+    if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
+        v.FechaCreacion = time_bogota.TiempoBogotaFormato()
+        v.FechaModificacion = time_bogota.TiempoBogotaFormato()
+        if _, err := models.AddInfoComplementariaTercero(&v); err == nil {
+            c.Ctx.Output.SetStatus(201)
+            c.Data["json"] = v
+        } else {
+            logs.Error(err)
+            //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+            c.Data["system"] = err
+            c.Abort("400")
+        }
+    } else {
+        logs.Error(err)
+        //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+        c.Data["system"] = err
+        c.Abort("400")
+    }
+    c.ServeJSON()
+}
+
+// PostPadre ...
+// @Title PostPadre
+// @Description create InfoComplementariaTercero Padre
+// @Param	body		body 	models.InfoComplementariaTercero	true		"body for InfoComplementariaTercero content"
+// @Success 201 {int} models.InfoComplementariaTercero
+// @Failure 400 the request contains incorrect syntax
+// @router /padre [post]
+func (c *InfoComplementariaTerceroController) PostPadre() {
+    var v models.InfoComplementariaTercero
+    var resultado map[string]interface{}
+    if err := json.Unmarshal(c.Ctx.Input.RequestBody, &resultado); err == nil {
+
+        datoJson, _ := json.Marshal(resultado["ProgramaAcademico"].(map[string]interface{})["Dato"])
+        //terceroJson,_ := json.Marshal( resultado["TerceroId"].(map[string]interface{}))
+        //infoComplemenJson, _ := json.Marshal(resultado["ProgramaAcademico"].(map[string]interface{})["InfoComplementaria"])
+        infoComplementariaPadre := map[string]interface{}{
+            "TerceroId":            resultado["TerceroId"].(map[string]interface{}),
+            "InfoComplementariaId": resultado["ProgramaAcademico"].(map[string]interface{})["InfoComplementaria"],
+            "Activo":               true,
+            "Dato":                 string(datoJson),
+            "FechaCreacion":        time_bogota.TiempoBogotaFormato(),
+            "FechaModificacion":    time_bogota.TiempoBogotaFormato(),
+        }
+        err := mapstructure.Decode(infoComplementariaPadre, &v)
+        if err != nil {
+            panic(err)
+        }
+
+        if _, err := models.AddInfoComplementariaTercero(&v); err == nil {
+            var va models.InfoComplementariaTercero
+            datoJson2, _ := json.Marshal(resultado["FechaInicio"].(map[string]interface{})["Dato"])
+            //terceroJson,_ := json.Marshal( resultado["TerceroId"].(map[string]interface{}))
+            //infoComplemenJson, _ := json.Marshal(resultado["ProgramaAcademico"].(map[string]interface{})["InfoComplementaria"])
+            infoComplementariaPadre2 := map[string]interface{}{
+                "TerceroId":                resultado["TerceroId"].(map[string]interface{}),
+                "InfoComplementariaId":     resultado["FechaInicio"].(map[string]interface{})["InfoComplementaria"],
+                "Activo":                   true,
+                "Dato":                     string(datoJson2),
+                "FechaCreacion":            time_bogota.TiempoBogotaFormato(),
+                "FechaModificacion":        time_bogota.TiempoBogotaFormato(),
+                "InfoCompleTerceroPadreId": v,
+            }
+            err := mapstructure.Decode(infoComplementariaPadre2, &va)
+            if err != nil {
+                panic(err)
+            }
+            if _, err := models.AddInfoComplementariaTercero(&va); err == nil {
+
+                var va models.InfoComplementariaTercero
+                datoJson3, _ := json.Marshal(resultado["FechaFin"].(map[string]interface{})["Dato"])
+                //terceroJson,_ := json.Marshal( resultado["TerceroId"].(map[string]interface{}))
+                //infoComplemenJson, _ := json.Marshal(resultado["ProgramaAcademico"].(map[string]interface{})["InfoComplementaria"])
+                infoComplementariaPadre3 := map[string]interface{}{
+                    "TerceroId":                resultado["TerceroId"].(map[string]interface{}),
+                    "InfoComplementariaId":     resultado["FechaFin"].(map[string]interface{})["InfoComplementaria"],
+                    "Activo":                   true,
+                    "Dato":                     string(datoJson3),
+                    "FechaCreacion":            time_bogota.TiempoBogotaFormato(),
+                    "FechaModificacion":        time_bogota.TiempoBogotaFormato(),
+                    "InfoCompleTerceroPadreId": v,
+                }
+                err := mapstructure.Decode(infoComplementariaPadre3, &va)
+                if err != nil {
+                    panic(err)
+                }
+
+                if _, err := models.AddInfoComplementariaTercero(&va); err == nil {
+
+                    var va models.InfoComplementariaTercero
+                    datoJson4, _ := json.Marshal(resultado["TituloTrabajoGrado"].(map[string]interface{})["Dato"])
+                    //terceroJson,_ := json.Marshal( resultado["TerceroId"].(map[string]interface{}))
+                    //infoComplemenJson, _ := json.Marshal(resultado["ProgramaAcademico"].(map[string]interface{})["InfoComplementaria"])
+                    infoComplementariaPadre3 := map[string]interface{}{
+                        "TerceroId":                resultado["TerceroId"].(map[string]interface{}),
+                        "InfoComplementariaId":     resultado["TituloTrabajoGrado"].(map[string]interface{})["InfoComplementaria"],
+                        "Activo":                   true,
+                        "Dato":                     string(datoJson4),
+                        "FechaCreacion":            time_bogota.TiempoBogotaFormato(),
+                        "FechaModificacion":        time_bogota.TiempoBogotaFormato(),
+                        "InfoCompleTerceroPadreId": v,
+                    }
+                    err := mapstructure.Decode(infoComplementariaPadre3, &va)
+                    if err != nil {
+                        panic(err)
+                    }
+                    if _, err := models.AddInfoComplementariaTercero(&va); err == nil {
+
+                        var va models.InfoComplementariaTercero
+                        datoJson4, _ := json.Marshal(resultado["DesTrabajoGrado"].(map[string]interface{})["Dato"])
+                        //terceroJson,_ := json.Marshal( resultado["TerceroId"].(map[string]interface{}))
+                        //infoComplemenJson, _ := json.Marshal(resultado["ProgramaAcademico"].(map[string]interface{})["InfoComplementaria"])
+                        infoComplementariaPadre3 := map[string]interface{}{
+                            "TerceroId":                resultado["TerceroId"].(map[string]interface{}),
+                            "InfoComplementariaId":     resultado["DesTrabajoGrado"].(map[string]interface{})["InfoComplementaria"],
+                            "Activo":                   true,
+                            "Dato":                     string(datoJson4),
+                            "FechaCreacion":            time_bogota.TiempoBogotaFormato(),
+                            "FechaModificacion":        time_bogota.TiempoBogotaFormato(),
+                            "InfoCompleTerceroPadreId": v,
+                        }
+                        err := mapstructure.Decode(infoComplementariaPadre3, &va)
+                        if err != nil {
+                            panic(err)
+                        }
+                        if _, err := models.AddInfoComplementariaTercero(&va); err == nil {
+
+                            var va models.InfoComplementariaTercero
+                            datoJson4, _ := json.Marshal(resultado["DocumentoId"].(map[string]interface{})["Dato"])
+                            //terceroJson,_ := json.Marshal( resultado["TerceroId"].(map[string]interface{}))
+                            //infoComplemenJson, _ := json.Marshal(resultado["ProgramaAcademico"].(map[string]interface{})["InfoComplementaria"])
+                            infoComplementariaPadre3 := map[string]interface{}{
+                                "TerceroId":                resultado["TerceroId"].(map[string]interface{}),
+                                "InfoComplementariaId":     resultado["DocumentoId"].(map[string]interface{})["InfoComplementaria"],
+                                "Activo":                   true,
+                                "Dato":                     string(datoJson4),
+                                "FechaCreacion":            time_bogota.TiempoBogotaFormato(),
+                                "FechaModificacion":        time_bogota.TiempoBogotaFormato(),
+                                "InfoCompleTerceroPadreId": v,
+                            }
+                            err := mapstructure.Decode(infoComplementariaPadre3, &va)
+                            if err != nil {
+                                panic(err)
+                            }
+                            if _, err := models.AddInfoComplementariaTercero(&va); err == nil {
+
+                                var va models.InfoComplementariaTercero
+                                datoJson4, _ := json.Marshal(resultado["NitUniversidad"].(map[string]interface{})["Dato"])
+                                //terceroJson,_ := json.Marshal( resultado["TerceroId"].(map[string]interface{}))
+                                //infoComplemenJson, _ := json.Marshal(resultado["ProgramaAcademico"].(map[string]interface{})["InfoComplementaria"])
+                                infoComplementariaPadre3 := map[string]interface{}{
+                                    "TerceroId":                resultado["TerceroId"].(map[string]interface{}),
+                                    "InfoComplementariaId":     resultado["NitUniversidad"].(map[string]interface{})["InfoComplementaria"],
+                                    "Activo":                   true,
+                                    "Dato":                     string(datoJson4),
+                                    "FechaCreacion":            time_bogota.TiempoBogotaFormato(),
+                                    "FechaModificacion":        time_bogota.TiempoBogotaFormato(),
+                                    "InfoCompleTerceroPadreId": v,
+                                }
+                                err := mapstructure.Decode(infoComplementariaPadre3, &va)
+                                if err != nil {
+                                    panic(err)
+                                }
+                                if _, err := models.AddInfoComplementariaTercero(&va); err == nil {
+
+                                    var va models.InfoComplementariaTercero
+                                    datoJson4, _ := json.Marshal(resultado["NivelFormacion"].(map[string]interface{})["Dato"])
+                                    //terceroJson,_ := json.Marshal( resultado["TerceroId"].(map[string]interface{}))
+                                    //infoComplemenJson, _ := json.Marshal(resultado["ProgramaAcademico"].(map[string]interface{})["InfoComplementaria"])
+                                    infoComplementariaPadre3 := map[string]interface{}{
+                                        "TerceroId":                resultado["TerceroId"].(map[string]interface{}),
+                                        "InfoComplementariaId":     resultado["NivelFormacion"].(map[string]interface{})["InfoComplementaria"],
+                                        "Activo":                   true,
+                                        "Dato":                     string(datoJson4),
+                                        "FechaCreacion":            time_bogota.TiempoBogotaFormato(),
+                                        "FechaModificacion":        time_bogota.TiempoBogotaFormato(),
+                                        "InfoCompleTerceroPadreId": v,
+                                    }
+                                    err := mapstructure.Decode(infoComplementariaPadre3, &va)
+                                    if err != nil {
+                                        panic(err)
+                                    }
+                                    if _, err := models.AddInfoComplementariaTercero(&va); err == nil {
+                                        c.Ctx.Output.SetStatus(201)
+                                        c.Data["json"] = v
+
+                                    } else {
+
+                                        logs.Error(err)
+                                        //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+                                        c.Data["system"] = err
+                                        c.Abort("400")
+                                        fmt.Println(c.Data["system"])
+                                        fmt.Println(err)
+                                    }
+
+
+
+
+                                } else {
+
+                                    logs.Error(err)
+                                    //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+                                    c.Data["system"] = err
+                                    c.Abort("400")
+                                    fmt.Println(c.Data["system"])
+                                    fmt.Println(err)
+                                }
+
+                            } else {
+
+                                logs.Error(err)
+                                //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+                                c.Data["system"] = err
+                                c.Abort("400")
+                                fmt.Println(c.Data["system"])
+                                fmt.Println(err)
+                            }
+
+                        } else {
+
+                            logs.Error(err)
+                            //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+                            c.Data["system"] = err
+                            c.Abort("400")
+                            fmt.Println(c.Data["system"])
+                            fmt.Println(err)
+                        }
+
+                    } else {
+
+                        logs.Error(err)
+                        //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+                        c.Data["system"] = err
+                        c.Abort("400")
+                        fmt.Println(c.Data["system"])
+                        fmt.Println(err)
+                    }
+
+                } else {
+
+                    logs.Error(err)
+                    //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+                    c.Data["system"] = err
+                    c.Abort("400")
+                    fmt.Println(c.Data["system"])
+                    fmt.Println(err)
+                }
+
+            } else {
+
+                logs.Error(err)
+                //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+                c.Data["system"] = err
+                c.Abort("400")
+                fmt.Println(c.Data["system"])
+                fmt.Println(err)
+            }
+
+        } else {
+
+            logs.Error(err)
+            //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+            c.Data["system"] = err
+            c.Abort("400")
+            fmt.Println(c.Data["system"])
+            fmt.Println(err)
+        }
+    } else {
+        logs.Error(err)
+        //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+        c.Data["system"] = err
+        c.Abort("400")
+    }
+    c.ServeJSON()
 }
 
 // GetOne ...
@@ -64,18 +323,18 @@ func (c *InfoComplementariaTerceroController) Post() {
 // @Failure 404 not found resource
 // @router /:id [get]
 func (c *InfoComplementariaTerceroController) GetOne() {
-	idStr := c.Ctx.Input.Param(":id")
-	id, _ := strconv.Atoi(idStr)
-	v, err := models.GetInfoComplementariaTerceroById(id)
-	if err != nil {
-		logs.Error(err)
-		//c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
-		c.Data["system"] = err
-		c.Abort("404")
-	} else {
-		c.Data["json"] = v
-	}
-	c.ServeJSON()
+    idStr := c.Ctx.Input.Param(":id")
+    id, _ := strconv.Atoi(idStr)
+    v, err := models.GetInfoComplementariaTerceroById(id)
+    if err != nil {
+        logs.Error(err)
+        //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+        c.Data["system"] = err
+        c.Abort("404")
+    } else {
+        c.Data["json"] = v
+    }
+    c.ServeJSON()
 }
 
 // GetAll ...
@@ -91,60 +350,60 @@ func (c *InfoComplementariaTerceroController) GetOne() {
 // @Failure 404 not found resource
 // @router / [get]
 func (c *InfoComplementariaTerceroController) GetAll() {
-	var fields []string
-	var sortby []string
-	var order []string
-	var query = make(map[string]string)
-	var limit int64 = 10
-	var offset int64
+    var fields []string
+    var sortby []string
+    var order []string
+    var query = make(map[string]string)
+    var limit int64 = 10
+    var offset int64
 
-	// fields: col1,col2,entity.col3
-	if v := c.GetString("fields"); v != "" {
-		fields = strings.Split(v, ",")
-	}
-	// limit: 10 (default is 10)
-	if v, err := c.GetInt64("limit"); err == nil {
-		limit = v
-	}
-	// offset: 0 (default is 0)
-	if v, err := c.GetInt64("offset"); err == nil {
-		offset = v
-	}
-	// sortby: col1,col2
-	if v := c.GetString("sortby"); v != "" {
-		sortby = strings.Split(v, ",")
-	}
-	// order: desc,asc
-	if v := c.GetString("order"); v != "" {
-		order = strings.Split(v, ",")
-	}
-	// query: k:v,k:v
-	if v := c.GetString("query"); v != "" {
-		for _, cond := range strings.Split(v, ",") {
-			kv := strings.SplitN(cond, ":", 2)
-			if len(kv) != 2 {
-				c.Data["json"] = errors.New("Error: invalid query key/value pair")
-				c.ServeJSON()
-				return
-			}
-			k, v := kv[0], kv[1]
-			query[k] = v
-		}
-	}
+    // fields: col1,col2,entity.col3
+    if v := c.GetString("fields"); v != "" {
+        fields = strings.Split(v, ",")
+    }
+    // limit: 10 (default is 10)
+    if v, err := c.GetInt64("limit"); err == nil {
+        limit = v
+    }
+    // offset: 0 (default is 0)
+    if v, err := c.GetInt64("offset"); err == nil {
+        offset = v
+    }
+    // sortby: col1,col2
+    if v := c.GetString("sortby"); v != "" {
+        sortby = strings.Split(v, ",")
+    }
+    // order: desc,asc
+    if v := c.GetString("order"); v != "" {
+        order = strings.Split(v, ",")
+    }
+    // query: k:v,k:v
+    if v := c.GetString("query"); v != "" {
+        for _, cond := range strings.Split(v, ",") {
+            kv := strings.SplitN(cond, ":", 2)
+            if len(kv) != 2 {
+                c.Data["json"] = errors.New("Error: invalid query key/value pair")
+                c.ServeJSON()
+                return
+            }
+            k, v := kv[0], kv[1]
+            query[k] = v
+        }
+    }
 
-	l, err := models.GetAllInfoComplementariaTercero(query, fields, sortby, order, offset, limit)
-	if err != nil {
-		logs.Error(err)
-		//c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
-		c.Data["system"] = err
-		c.Abort("404")
-	} else {
-		if l == nil {
-			l = append(l, map[string]interface{}{})
-		}
-		c.Data["json"] = l
-	}
-	c.ServeJSON()
+    l, err := models.GetAllInfoComplementariaTercero(query, fields, sortby, order, offset, limit)
+    if err != nil {
+        logs.Error(err)
+        //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+        c.Data["system"] = err
+        c.Abort("404")
+    } else {
+        if l == nil {
+            l = append(l, map[string]interface{}{})
+        }
+        c.Data["json"] = l
+    }
+    c.ServeJSON()
 }
 
 // Put ...
@@ -156,30 +415,30 @@ func (c *InfoComplementariaTerceroController) GetAll() {
 // @Failure 400 the request contains incorrect syntax
 // @router /:id [put]
 func (c *InfoComplementariaTerceroController) Put() {
-	idStr := c.Ctx.Input.Param(":id")
-	id, _ := strconv.Atoi(idStr)
-	v := models.InfoComplementariaTercero{Id: id}
-	if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
-		infoAd, _ := models.GetInfoComplementariaTerceroById(id)
-		if infoAd != nil {
-			v.FechaCreacion = time_bogota.TiempoCorreccionFormato(infoAd.FechaCreacion)
-			v.FechaModificacion = time_bogota.TiempoBogotaFormato()
-		}
-		if err := models.UpdateInfoComplementariaTerceroById(&v); err == nil {
-			c.Data["json"] = v
-		} else {
-			logs.Error(err)
-			//c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
-			c.Data["system"] = err
-			c.Abort("400")
-		}
-	} else {
-		logs.Error(err)
-		//c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
-		c.Data["system"] = err
-		c.Abort("400")
-	}
-	c.ServeJSON()
+    idStr := c.Ctx.Input.Param(":id")
+    id, _ := strconv.Atoi(idStr)
+    v := models.InfoComplementariaTercero{Id: id}
+    if err := json.Unmarshal(c.Ctx.Input.RequestBody, &v); err == nil {
+        infoAd, _ := models.GetInfoComplementariaTerceroById(id)
+        if infoAd != nil {
+            v.FechaCreacion = time_bogota.TiempoCorreccionFormato(infoAd.FechaCreacion)
+            v.FechaModificacion = time_bogota.TiempoBogotaFormato()
+        }
+        if err := models.UpdateInfoComplementariaTerceroById(&v); err == nil {
+            c.Data["json"] = v
+        } else {
+            logs.Error(err)
+            //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+            c.Data["system"] = err
+            c.Abort("400")
+        }
+    } else {
+        logs.Error(err)
+        //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+        c.Data["system"] = err
+        c.Abort("400")
+    }
+    c.ServeJSON()
 }
 
 // Delete ...
@@ -190,15 +449,15 @@ func (c *InfoComplementariaTerceroController) Put() {
 // @Failure 404 not found resource
 // @router /:id [delete]
 func (c *InfoComplementariaTerceroController) Delete() {
-	idStr := c.Ctx.Input.Param(":id")
-	id, _ := strconv.Atoi(idStr)
-	if err := models.DeleteInfoComplementariaTercero(id); err == nil {
-		c.Data["json"] = map[string]interface{}{"Id": id}
-	} else {
-		logs.Error(err)
-		//c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
-		c.Data["system"] = err
-		c.Abort("404")
-	}
-	c.ServeJSON()
+    idStr := c.Ctx.Input.Param(":id")
+    id, _ := strconv.Atoi(idStr)
+    if err := models.DeleteInfoComplementariaTercero(id); err == nil {
+        c.Data["json"] = map[string]interface{}{"Id": id}
+    } else {
+        logs.Error(err)
+        //c.Data["development"] = map[string]interface{}{"Code": "000", "Body": err.Error(), "Type": "error"}
+        c.Data["system"] = err
+        c.Abort("404")
+    }
+    c.ServeJSON()
 }

--- a/database/migrations/20210105_095124_insert_tabla_info_complementaria.go
+++ b/database/migrations/20210105_095124_insert_tabla_info_complementaria.go
@@ -23,6 +23,7 @@ func (m *InsertTablaInfoComplementaria_20210105_095124) Up() {
 	m.SQL("INSERT INTO terceros.info_complementaria (nombre, codigo_abreviacion, activo, grupo_info_complementaria_id, fecha_creacion, fecha_modificacion) VALUES ('AREA_CONOCIMIENTO', 'AREA_CONOCIMIENTO', TRUE, 20, LOCALTIMESTAMP, LOCALTIMESTAMP);")
 	m.SQL("INSERT INTO terceros.info_complementaria (nombre, codigo_abreviacion, activo, grupo_info_complementaria_id, fecha_creacion, fecha_modificacion) VALUES ('FORMACION_ACADEMICA', 'FORMACION_ACADEMICA', TRUE, 20, LOCALTIMESTAMP, LOCALTIMESTAMP);")
 	m.SQL("INSERT INTO terceros.info_complementaria (nombre, codigo_abreviacion, activo, grupo_info_complementaria_id, fecha_creacion, fecha_modificacion) VALUES ('INSTITUCION', 'INSTITUCION', TRUE, 20, LOCALTIMESTAMP, LOCALTIMESTAMP);")
+	m.SQL("INSERT INTO terceros.info_complementaria (nombre, codigo_abreviacion, activo, grupo_info_complementaria_id, fecha_creacion, fecha_modificacion) VALUES ('NIVEL_FORMACION', 'NIVEL_FORMACION', TRUE, 18, LOCALTIMESTAMP, LOCALTIMESTAMP);")
 
 }
 
@@ -30,4 +31,5 @@ func (m *InsertTablaInfoComplementaria_20210105_095124) Up() {
 func (m *InsertTablaInfoComplementaria_20210105_095124) Down() {
 	// use m.SQL("DROP TABLE ...") to reverse schema update
 	m.SQL("DELETE FROM terceros.info_complementaria WHERE grupo_info_complementaria_id = 20 ;")
+	m.SQL("DELETE FROM terceros.info_complementaria WHERE nombre = 'NIVEL_FORMACION' and WHERE grupo_info_complementaria_id = 18 ;")
 }

--- a/database/migrations/20210118_112024_modify_table_info_complementaria_tercero.go
+++ b/database/migrations/20210118_112024_modify_table_info_complementaria_tercero.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"github.com/astaxie/beego/migration"
+	"io/ioutil"
+	"strings"
+)
+
+// DO NOT MODIFY
+type ModifyTableInfoComplementariaTercero_20210118_112024 struct {
+	migration.Migration
+}
+
+// DO NOT MODIFY
+func init() {
+	m := &ModifyTableInfoComplementariaTercero_20210118_112024{}
+	m.Created = "20210118_112024"
+
+	migration.Register("ModifyTableInfoComplementariaTercero_20210118_112024", m)
+}
+
+// Run the migrations
+func (m *ModifyTableInfoComplementariaTercero_20210118_112024) Up() {
+	// use m.SQL("CREATE TABLE ...") to make schema update
+	file, err := ioutil.ReadFile("../scripts/20210105_152820_agregar_campos_info_complementaria_tercero_padre.up.sql")
+
+	if err != nil {
+		// handle error
+		fmt.Println(err)
+	}
+
+	requests := strings.Split(string(file), ";")
+
+	for _, request := range requests {
+		fmt.Println(request)
+		m.SQL(request)
+		// do whatever you need with result and error
+	}
+}
+
+// Reverse the migrations
+func (m *ModifyTableInfoComplementariaTercero_20210118_112024) Down() {
+	file, err := ioutil.ReadFile("../scripts/20210105_152820_agregar_campos_info_complementaria_tercero_padre.down.sql")
+
+	if err != nil {
+		// handle error
+		fmt.Println(err)
+	}
+
+	requests := strings.Split(string(file), ";")
+
+	for _, request := range requests {
+		fmt.Println(request)
+		m.SQL(request)
+		// do whatever you need with result and error
+	}
+	// use m.SQL("DROP TABLE ...") to reverse schema update
+
+
+}

--- a/database/scripts/20210105_152820_agregar_campos_info_complementaria_tercero_padre.down.sql
+++ b/database/scripts/20210105_152820_agregar_campos_info_complementaria_tercero_padre.down.sql
@@ -1,0 +1,6 @@
+-- Eliminar relación
+ALTER TABLE tercero_crud.info_complementaria_tercero DROP CONSTRAINT IF EXISTS fk_info_complementaria_tercero_padre_info_complementaria_tercero CASCADE;
+
+-- Eliminar campos
+ALTER TABLE tercero_crud.info_complementaria_tercero
+DROP COLUMN IF EXISTS info_complementaria_tercero_padre_id;

--- a/database/scripts/20210105_152820_agregar_campos_info_complementaria_tercero_padre.down.sql
+++ b/database/scripts/20210105_152820_agregar_campos_info_complementaria_tercero_padre.down.sql
@@ -1,6 +1,6 @@
 -- Eliminar relación
-ALTER TABLE tercero_crud.info_complementaria_tercero DROP CONSTRAINT IF EXISTS fk_info_complementaria_tercero_padre_info_complementaria_tercero CASCADE;
+ALTER TABLE terceros.info_complementaria_tercero DROP CONSTRAINT IF EXISTS fk_info_complementaria_tercero_padre_info_complementaria_tercero CASCADE;
 
 -- Eliminar campos
-ALTER TABLE tercero_crud.info_complementaria_tercero
+ALTER TABLE terceros.info_complementaria_tercero
 DROP COLUMN IF EXISTS info_complementaria_tercero_padre_id;

--- a/database/scripts/20210105_152820_agregar_campos_info_complementaria_tercero_padre.up.sql
+++ b/database/scripts/20210105_152820_agregar_campos_info_complementaria_tercero_padre.up.sql
@@ -1,9 +1,9 @@
--- Campo relacion nivel formacion padre
-ALTER TABLE tercero_crud.info_complementaria_tercero ADD COLUMN info_complementaria_tercero_padre_id integer;
+-- Campo relacion info complementaria tercero padre
+ALTER TABLE terceros.info_complementaria_tercero ADD COLUMN info_complementaria_tercero_padre_id integer;
 
 
--- object: fk_nivel_formacion_padre_nivel_formacion | type: CONSTRAINT --
--- ALTER TABLE proyecto_academico.nivel_formacion DROP CONSTRAINT IF EXISTS fk_nivel_formacion_padre_nivel_formacion CASCADE;
-ALTER TABLE tercero_crud.info_complementaria_tercero ADD CONSTRAINT fk_info_complementaria_tercero_padre_info_complementaria_tercero FOREIGN KEY (info_complementaria_tercero_padre_id)
-REFERENCES tercero_crud.info_complementaria_tercero (id) MATCH FULL
+-- object: fk_info_complementaria_tercero_padre_info_complementaria_tercero | type: CONSTRAINT --
+-- ALTER TABLE erceros.info_complementaria_tercero DROP CONSTRAINT IF EXISTS fk_info_complementaria_tercero_padre_info_complementaria_tercero CASCADE;
+ALTER TABLE terceros.info_complementaria_tercero ADD CONSTRAINT fk_info_complementaria_tercero_padre_info_complementaria_tercero FOREIGN KEY (info_complementaria_tercero_padre_id)
+REFERENCES terceros.info_complementaria_tercero (id) MATCH FULL
 ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/database/scripts/20210105_152820_agregar_campos_info_complementaria_tercero_padre.up.sql
+++ b/database/scripts/20210105_152820_agregar_campos_info_complementaria_tercero_padre.up.sql
@@ -1,0 +1,9 @@
+-- Campo relacion nivel formacion padre
+ALTER TABLE tercero_crud.info_complementaria_tercero ADD COLUMN info_complementaria_tercero_padre_id integer;
+
+
+-- object: fk_nivel_formacion_padre_nivel_formacion | type: CONSTRAINT --
+-- ALTER TABLE proyecto_academico.nivel_formacion DROP CONSTRAINT IF EXISTS fk_nivel_formacion_padre_nivel_formacion CASCADE;
+ALTER TABLE tercero_crud.info_complementaria_tercero ADD CONSTRAINT fk_info_complementaria_tercero_padre_info_complementaria_tercero FOREIGN KEY (info_complementaria_tercero_padre_id)
+REFERENCES tercero_crud.info_complementaria_tercero (id) MATCH FULL
+ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/models/info_complementaria_tercero.go
+++ b/models/info_complementaria_tercero.go
@@ -16,6 +16,7 @@ type InfoComplementariaTercero struct {
 	Activo               bool                `orm:"column(activo)"`
 	FechaCreacion        string           `orm:"column(fecha_creacion);type(timestamp without time zone)"`
 	FechaModificacion    string           `orm:"column(fecha_modificacion);type(timestamp without time zone)"`
+	InfoCompleTerceroPadreId *InfoComplementariaTercero `orm:"column(info_complementaria_tercero_padre_id);rel(fk);null"`
 }
 
 func (t *InfoComplementariaTercero) TableName() string {

--- a/models/info_complementaria_tercero.go
+++ b/models/info_complementaria_tercero.go
@@ -3,9 +3,9 @@ package models
 import (
 	"errors"
 	"fmt"
+	"github.com/astaxie/beego/orm"
 	"reflect"
 	"strings"
-	"github.com/astaxie/beego/orm"
 )
 
 type InfoComplementariaTercero struct {
@@ -34,6 +34,7 @@ func AddInfoComplementariaTercero(m *InfoComplementariaTercero) (id int64, err e
 	id, err = o.Insert(m)
 	return
 }
+
 
 // GetInfoComplementariaTerceroById retrieves InfoComplementariaTercero by Id. Returns error if
 // Id doesn't exist

--- a/routers/commentsRouter_controllers.go
+++ b/routers/commentsRouter_controllers.go
@@ -153,6 +153,15 @@ func init() {
 
     beego.GlobalControllerRouter["github.com/udistrital/terceros_crud/controllers:InfoComplementariaTerceroController"] = append(beego.GlobalControllerRouter["github.com/udistrital/terceros_crud/controllers:InfoComplementariaTerceroController"],
         beego.ControllerComments{
+            Method: "PostPadre",
+            Router: `/padre`,
+            AllowHTTPMethods: []string{"post"},
+            MethodParams: param.Make(),
+            Filters: nil,
+            Params: nil})
+
+    beego.GlobalControllerRouter["github.com/udistrital/terceros_crud/controllers:InfoComplementariaTerceroController"] = append(beego.GlobalControllerRouter["github.com/udistrital/terceros_crud/controllers:InfoComplementariaTerceroController"],
+        beego.ControllerComments{
             Method: "GetAll",
             Router: `/`,
             AllowHTTPMethods: []string{"get"},


### PR DESCRIPTION
Se modifica el modelo de la tabla info_complementaria_tercero, agregando un nuevo campo nulo llamado InfoCompleTerceroPadreId donde se relaciona a si misma, luego se crea un nuevo metodo en el controlador de dicho modelo llamado PostPadre() donde le llevaran peticiones con terminacion del endpoint /padre y el funcionamiento y paso a paso de como funciona el controlador se explica detalladamente en https://github.com/udistrital/produccion_academica_cliente/issues/54
De momento se realizaron pruebas locales y no afecta a los demas campos en dicha tabla y hace el proceso de asignacion de padre de manera satisfactoria